### PR TITLE
removed exception throwing when  is emty

### DIFF
--- a/src/MultiSelect.php
+++ b/src/MultiSelect.php
@@ -39,18 +39,6 @@ class MultiSelect extends InputWidget
     public $clientOptions = [];
 
     /**
-     * Initializes the widget.
-     * @throws InvalidConfigException
-     */
-    public function init()
-    {
-        if (empty($this->data)) {
-            throw new  InvalidConfigException('"Multiselect::$data" attribute cannot be blank or an empty array.');
-        }
-        parent::init();
-    }
-
-    /**
      * @inheritdoc
      * @throws InvalidParamException
      */


### PR DESCRIPTION
I have removed this exception because I got a use case with an empty data array. I think not only I can have such use cases [(issue)](https://github.com/2amigos/yii2-multi-select-widget/issues/22). Also, the original MultiSelect Bootstrap plugin has the option `disableIfEmpty`.